### PR TITLE
[CHANGE] Switch to `django-solo` to provide the singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+## Changed
+
+- Switch to `django-solo` to provide the singleton for the compliance model, instead of the custom implementation
+
 ## \[1.2.0\] - 2024-10-10
 
 ### Changed

--- a/memberaudit_securegroups/admin.py
+++ b/memberaudit_securegroups/admin.py
@@ -7,6 +7,7 @@ from typing import Any
 
 # Third Party
 import humanize
+from solo.admin import SingletonModelAdmin
 
 # Django
 from django.contrib import admin
@@ -30,42 +31,6 @@ from memberaudit_securegroups.models import (
     SkillSetFilter,
     TimeInCorporationFilter,
 )
-
-
-class SingletonModelAdmin(admin.ModelAdmin):
-    """
-    Prevents Django admin users deleting the singleton or adding extra rows.
-    """
-
-    actions = None  # Removes the default delete action.
-
-    def has_delete_permission(
-        self, request, obj=None  # pylint: disable=unused-argument
-    ):
-        """
-        Has "delete" permission
-
-        :param request:
-        :type request:
-        :param obj:
-        :type obj:
-        :return:
-        :rtype:
-        """
-
-        return False
-
-    def has_add_permission(self, request):  # pylint: disable=unused-argument
-        """
-        Has "add" permission
-
-        :param request:
-        :type request:
-        :return:
-        :rtype:
-        """
-
-        return self.model.objects.all().count() == 0
 
 
 @admin.register(ActivityFilter)

--- a/memberaudit_securegroups/models.py
+++ b/memberaudit_securegroups/models.py
@@ -8,10 +8,10 @@ from collections import defaultdict
 
 # Third Party
 import humanize
+from solo.models import SingletonModel
 
 # Django
 from django.contrib.auth.models import User
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import F, OuterRef, Q, Subquery
@@ -43,65 +43,6 @@ def _get_threshold_date(timedelta_in_days: int) -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         days=timedelta_in_days
     )
-
-
-class SingletonModel(models.Model):
-    """
-    SingletonModel
-    """
-
-    class Meta:
-        """
-        Model meta definitions
-        """
-
-        abstract = True
-
-    def delete(self, *args, **kwargs):
-        """
-        "Delete" action
-        :param args:
-        :param kwargs:
-        :return:
-        """
-
-        pass  # pylint: disable=unnecessary-pass
-
-    def set_cache(self):
-        """
-        Setting cache
-        :return:
-        """
-
-        cache.set(self.__class__.__name__, self)
-
-    def save(self, *args, **kwargs):
-        """
-        "Save" action
-        :param args:
-        :param kwargs:
-        :return:
-        """
-
-        self.pk = 1
-        super().save(*args, **kwargs)
-
-        self.set_cache()
-
-    @classmethod
-    def load(cls):
-        """
-        Get cache
-        :return:
-        """
-
-        if cache.get(cls.__name__) is None:
-            obj, created = cls.objects.get_or_create(pk=1)
-
-            if not created:
-                obj.set_cache()
-
-        return cache.get(cls.__name__)
 
 
 class BaseFilter(models.Model):


### PR DESCRIPTION
## Description

### Changed

- Switch to `django-solo` to provide the singleton for the Compliance model, instead of the custom implementation

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
